### PR TITLE
add cache busting to Server#populate

### DIFF
--- a/lib/cloudservers/server.rb
+++ b/lib/cloudservers/server.rb
@@ -41,7 +41,8 @@ module CloudServers
     #  >> server.refresh
     #  => true
     def populate
-      response = @connection.csreq("GET",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(@id.to_s)}",@svrmgmtport,@svrmgmtscheme)
+      anti_cache_param="cacheid=#{Time.now.to_i}"
+      response = @connection.csreq("GET",@svrmgmthost,"#{@svrmgmtpath}/servers/#{URI.encode(@id.to_s)}?#{anti_cache_param}",@svrmgmtport,@svrmgmtscheme)
       CloudServers::Exception.raise_exception(response) unless response.code.match(/^20.$/)
       data = JSON.parse(response.body)["server"]
       @id        = data["id"]


### PR DESCRIPTION
This is required when running a script that deletes/rebuilds a server,
and then polls to check when it has finished to allow further tasks to
be done once it is up and running (like SSHing to it and running
bootstraping scripts)

With rackspace caching as of May 2012, it seems to return the status of
the server up to 30 minutes old, which is useless to poll to test if it
is ready for further actions
