### PR TITLE
Update connection.rb

### DIFF
--- a/lib/cloudservers/connection.rb
+++ b/lib/cloudservers/connection.rb
@@ -132,7 +132,8 @@ module CloudServers
     #   => [{:status=>"ACTIVE", :imageId=>10, :progress=>100, :metadata=>{}, :addresses=>{:public=>["x.x.x.x"], :private=>["x.x.x.x"]}, :name=>"demo-standingcloud-lts", :id=>168867, :flavorId=>1, :hostId=>"xxxxxx"}, 
     #       {:status=>"ACTIVE", :imageId=>8, :progress=>100, :metadata=>{}, :addresses=>{:public=>["x.x.x.x"], :private=>["x.x.x.x"]}, :name=>"demo-aicache1", :id=>187853, :flavorId=>3, :hostId=>"xxxxxx"}]
     def list_servers_detail(options = {})
-      path = CloudServers.paginate(options).empty? ? "#{svrmgmtpath}/servers/detail" : "#{svrmgmtpath}/servers/detail?#{CloudServers.paginate(options)}"
+      anti_cache_param="cacheid=#{Time.now.to_i}"
+      path = CloudServers.paginate(options).empty? ? "#{svrmgmtpath}/servers/detail?#{anti_cache_param}" : "#{svrmgmtpath}/servers/detail?#{CloudServers.paginate(options)}&#{anti_cache_param}"
       response = csreq("GET",svrmgmthost,path,svrmgmtport,svrmgmtscheme)
       CloudServers::Exception.raise_exception(response) unless response.code.match(/^20.$/)
       CloudServers.symbolize_keys(JSON.parse(response.body)["servers"])


### PR DESCRIPTION
The Apache Deltacloud Project is using the ruby-cloudservers gem to abstract the Rackspace-API.  Deltacloud heavily uses the method list_servers_detail() to fetch server details, but this method returns only cached stuff. For example when launching a new server at rackspace, this method will not return the new instance until a number of minutes after it was created. For more details have a look at: https://issues.apache.org/jira/browse/DTACLOUD-319

The attached patch will fix this issue as I included the anti_cache_param to the list_servers_detail method to avoid caching stuff.
